### PR TITLE
release(v3.8.0)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,16 +6,15 @@ updates:
       interval: daily
     reviewers:
       - asmahood
-    ignore:
-      # We can customize this per repo but as a starting point we may want to ignore all major updates
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+    labels:
+      - "type::Dependencies"
+      - "dep::Javascript"
   - package-ecosystem: docker
     directory: "/"
     schedule:
       interval: daily
     reviewers:
       - asmahood
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+    labels:
+      - "type::Dependencies"
+      - "dep::Docker"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish Docker image
+name: Publish And Deploy
 on:
   release:
     types: [created]
@@ -20,15 +20,25 @@ jobs:
           service_account: "${{ secrets.GCP_SA }}"
       - name: Configure Docker
         run: gcloud auth configure-docker us-east1-docker.pkg.dev
-      # - name: Login to Artifact Registry
-      #   uses: docker/login-action@v1
-      #   with:
-      #     registry: us-east1-docker.pkg.dev
-      #     username: oauth2accesstoken
-      #     password: ${{ steps.auth.outputs.access_token }}
       - name: Build the tagged Docker image
         run: docker build --rm --no-cache -t us-east1-docker.pkg.dev/${{ secrets.GCP_PROJECT }}/uwpokerclub-docker/app:${GITHUB_REF##*/} -t us-east1-docker.pkg.dev/${{ secrets.GCP_PROJECT }}/uwpokerclub-docker/app:latest .
       - name: Push the tagged Docker image
         run: docker push us-east1-docker.pkg.dev/${{ secrets.GCP_PROJECT }}/uwpokerclub-docker/app:${GITHUB_REF##*/}
       - name: Push the latest Docker image
         run: docker push us-east1-docker.pkg.dev/${{ secrets.GCP_PROJECT }}/uwpokerclub-docker/app:latest
+  deploy:
+    name: Deploy version to Google Cloud
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    needs: push_to_artifact_registry
+    steps:
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: '${{ secrets.GCP_WIP }}'
+          service_account: '${{ secrets.GCP_SA }}'
+      - name: Deploy
+        run: gcloud run deploy app --region=us-east1 --image=us-east1-docker.pkg.dev/${{ secrets.GCP_PROJECT }}/uwpokerclub-docker/app:${GITHUB_REF##*/}
+    

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@testing-library/user-event": "^13.2.1",
     "@types/jest": "^27.5.2",
     "@types/node": "^16.7.13",
-    "@types/react": "^18.2.30",
+    "@types/react": "^18.2.31",
     "@types/react-dom": "^18.2.14",
     "@types/react-transition-group": "^4.4.8",
     "bootstrap": "^5.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "private": true,
   "proxy": "http://localhost:5000",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@testing-library/user-event": "^13.2.1",
     "@types/jest": "^27.5.2",
     "@types/node": "^16.7.13",
-    "@types/react": "^18.2.29",
+    "@types/react": "^18.2.30",
     "@types/react-dom": "^18.2.14",
     "@types/react-transition-group": "^4.4.8",
     "bootstrap": "^5.3.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@testing-library/user-event": "^13.2.1",
     "@types/jest": "^27.5.2",
     "@types/node": "^16.7.13",
-    "@types/react": "^18.2.25",
+    "@types/react": "^18.2.28",
     "@types/react-dom": "^18.2.9",
     "@types/react-transition-group": "^4.4.7",
     "bootstrap": "^5.3.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@types/node": "^16.7.13",
     "@types/react": "^18.2.29",
     "@types/react-dom": "^18.2.13",
-    "@types/react-transition-group": "^4.4.7",
+    "@types/react-transition-group": "^4.4.8",
     "bootstrap": "^5.3.2",
     "http-proxy-middleware": "^2.0.6",
     "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@types/jest": "^27.5.2",
     "@types/node": "^16.7.13",
     "@types/react": "^18.2.28",
-    "@types/react-dom": "^18.2.9",
+    "@types/react-dom": "^18.2.13",
     "@types/react-transition-group": "^4.4.7",
     "bootstrap": "^5.3.2",
     "http-proxy-middleware": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "react-scripts": "5.0.1",
     "react-select": "^5.7.7",
     "react-transition-group": "^4.4.2",
-    "sass": "^1.69.0",
+    "sass": "^1.69.4",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@testing-library/user-event": "^13.2.1",
     "@types/jest": "^27.5.2",
     "@types/node": "^16.7.13",
-    "@types/react": "^18.2.28",
+    "@types/react": "^18.2.29",
     "@types/react-dom": "^18.2.13",
     "@types/react-transition-group": "^4.4.7",
     "bootstrap": "^5.3.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@types/jest": "^27.5.2",
     "@types/node": "^16.7.13",
     "@types/react": "^18.2.29",
-    "@types/react-dom": "^18.2.13",
+    "@types/react-dom": "^18.2.14",
     "@types/react-transition-group": "^4.4.8",
     "bootstrap": "^5.3.2",
     "http-proxy-middleware": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "private": true,
   "proxy": "http://localhost:5000",
   "dependencies": {

--- a/src/shared/components/ResponsiveNavbar/ResponsiveNavbar.tsx
+++ b/src/shared/components/ResponsiveNavbar/ResponsiveNavbar.tsx
@@ -27,6 +27,10 @@ const links = [
     label: "JOIN",
     href: "/join",
   },
+  { // TODO: Temporary, remove after election period
+    label: "VOTE NOW",
+    href: "/election"
+  }
 ];
 
 function ResponsiveNavbar(): ReactElement {

--- a/src/shared/components/ResponsiveNavbar/ResponsiveNavbar.tsx
+++ b/src/shared/components/ResponsiveNavbar/ResponsiveNavbar.tsx
@@ -27,10 +27,6 @@ const links = [
     label: "JOIN",
     href: "/join",
   },
-  { // TODO: Temporary, remove after election period
-    label: "VOTE NOW",
-    href: "/election"
-  }
 ];
 
 function ResponsiveNavbar(): ReactElement {

--- a/src/views/Main/components/ElectionEmbed.tsx
+++ b/src/views/Main/components/ElectionEmbed.tsx
@@ -1,5 +1,81 @@
 import React from "react";
 
+export function ResultsEmbed() {
+  return (
+    <div
+      id="rv-embed-results"
+      style={{
+        maxWidth: "1140px",
+        marginLeft: "auto",
+        marginRight: "auto",
+        paddingLeft: "2px",
+        paddingRight: "2px",
+      }}
+    >
+      <iframe
+        width="100%"
+        height="650"
+        style={{
+          border: "2px solid #EEEEEE",
+          borderRadius: "10px",
+          maxWidth: "1140px",
+        }}
+        title="Winter 2024 Election election powered by RankedVote"
+        loading="lazy"
+        src="https://app.rankedvote.co/rv/uwpsc-w24/results/embed-rv/"
+      ></iframe>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <div
+          style={{
+            color: "#B0B7C3",
+            fontSize: "14px",
+            textAlign: "left",
+            marginTop: "2px",
+            marginLeft: "10px",
+          }}
+        >
+          <strong>
+            Not loading?{" "}
+            <a
+              href="https://app.rankedvote.co/rv/uwpsc-w24/results/embed-rv/"
+              style={{ color: "#B0B7C3", fontSize: "14px" }}
+            >
+              Click here
+            </a>
+          </strong>
+        </div>{" "}
+        <div
+          style={{
+            color: "#B0B7C3",
+            fontSize: "14px",
+            textAlign: "right",
+            marginTop: "2px",
+            marginRight: "10px",
+          }}
+        >
+          <strong>
+            <em>
+              Powered by{" "}
+              <a
+                href="https://www.rankedvote.co"
+                style={{ color: "#7540EE", fontSize: "14px" }}
+              >
+                RankedVote
+              </a>
+            </em>
+          </strong>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function ElectionEmbed() {
   return (
     <div

--- a/src/views/Main/components/ElectionEmbed.tsx
+++ b/src/views/Main/components/ElectionEmbed.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+
+export function ElectionEmbed() {
+  return (
+    <div
+      id="rv-embed-vote"
+      style={{
+        maxWidth: "1140px",
+        marginLeft: "auto",
+        marginRight: "auto",
+        paddingLeft: "2px",
+        paddingRight: "2px",
+      }}
+    >
+      <iframe
+        width="100%"
+        height="650"
+        style={{
+          border: "2px solid #EEEEEE",
+          borderRadius: "10px",
+          maxWidth: "1140px",
+        }}
+        title="Winter 2024 Election election powered by RankedVote"
+        loading="lazy"
+        src="https://app.rankedvote.co/rv/uwpsc-w24/vote/embed-rv/"
+      ></iframe>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <div
+          style={{
+            color: "#B0B7C3",
+            fontSize: "14px",
+            textAlign: "left",
+            marginTop: "2px",
+            marginLeft: "10px",
+          }}
+        >
+          <strong>
+            Not loading?{" "}
+            <a
+              href="https://app.rankedvote.co/rv/uwpsc-w24/vote/embed-rv/"
+              style={{ color: "#B0B7C3", fontSize: "14px" }}
+            >
+              Click here
+            </a>
+          </strong>
+        </div>{" "}
+        <div
+          style={{
+            color: "#B0B7C3",
+            fontSize: "14px",
+            textAlign: "right",
+            marginTop: "2px",
+            marginRight: "10px",
+          }}
+        >
+          <strong>
+            <em>
+              Powered by{" "}
+              <a
+                href="https://www.rankedvote.co"
+                style={{ color: "#7540EE", fontSize: "14px" }}
+              >
+                RankedVote
+              </a>
+            </em>
+          </strong>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/views/Main/components/Main.tsx
+++ b/src/views/Main/components/Main.tsx
@@ -8,7 +8,7 @@ import { Navigate, useLocation } from "react-router-dom";
 import ResponsiveNavbar from "../../../shared/components/ResponsiveNavbar/ResponsiveNavbar";
 import Gallery from "../views/Gallery";
 import Sponsors from "../views/Sponsors";
-import { ElectionEmbed } from "./ElectionEmbed";
+import { ResultsEmbed } from "./ElectionEmbed";
 
 function Main(): ReactElement {
   const location = useLocation();
@@ -24,7 +24,7 @@ function Main(): ReactElement {
         <Route path="/gallery" element={<Gallery />} />
         <Route path="/sponsors" element={<Sponsors />} />
         <Route path="/join" element={<Join />} />
-        <Route path="/election" element={<ElectionEmbed />} />
+        <Route path="/election" element={<ResultsEmbed />} />
       </Routes>
     </>
   );

--- a/src/views/Main/components/Main.tsx
+++ b/src/views/Main/components/Main.tsx
@@ -8,6 +8,7 @@ import { Navigate, useLocation } from "react-router-dom";
 import ResponsiveNavbar from "../../../shared/components/ResponsiveNavbar/ResponsiveNavbar";
 import Gallery from "../views/Gallery";
 import Sponsors from "../views/Sponsors";
+import { ElectionEmbed } from "./ElectionEmbed";
 
 function Main(): ReactElement {
   const location = useLocation();
@@ -23,6 +24,7 @@ function Main(): ReactElement {
         <Route path="/gallery" element={<Gallery />} />
         <Route path="/sponsors" element={<Sponsors />} />
         <Route path="/join" element={<Join />} />
+        <Route path="/election" element={<ElectionEmbed />} />
       </Routes>
     </>
   );

--- a/src/views/Main/views/Join/components/Join.scss
+++ b/src/views/Main/views/Join/components/Join.scss
@@ -24,8 +24,13 @@
   align-items: center;
 }
 
-.highlited-item {
+.socials-list li.highlight {
   border: 0.08rem solid goldenrod;
+  border-radius: 1rem;
+}
+
+.socials-list li.highlight a.text-link {
+  color: goldenrod !important;
 }
 
 .socials-list a,

--- a/src/views/Main/views/Join/components/Join.tsx
+++ b/src/views/Main/views/Join/components/Join.tsx
@@ -7,6 +7,7 @@ import {
   emailLine,
 } from "../../../../../assets";
 import "./Join.scss";
+import { Link } from "react-router-dom";
 
 const Join = () => {
   return (
@@ -26,15 +27,11 @@ const Join = () => {
           </div>
           <div className="col-lg">
             <ul className="socials-list">
-              {/* <li>
-                <a className="nav-link" href=""></a>
-              </li> */}
-              {/*<li>
-              <a className="form-link" href="https://forms.gle/p7hB6XbTPfsdijrE6" target="_blank" rel="noreferrer">
-              <img src={formsLine} className="mr-4 pl-1 pr-2" alt=""/>
-                  2023 WINTER MIDTERM
-                </a>
-            </li>*/}
+              <li className="highlight">
+                <Link className="text-link center" to={"/election"}>
+                  VOTE FOR THE WINTER 2024 EXEC TEAM
+                </Link>
+              </li>
               <li>
                 <a
                   className="text-link"

--- a/src/views/Main/views/Join/components/Join.tsx
+++ b/src/views/Main/views/Join/components/Join.tsx
@@ -29,7 +29,7 @@ const Join = () => {
             <ul className="socials-list">
               <li className="highlight">
                 <Link className="text-link center" to={"/election"}>
-                  VOTE FOR THE WINTER 2024 EXEC TEAM
+                  VIEW THE RESULTS FOR THE WINTER 2024 ELECTION
                 </Link>
               </li>
               <li>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7919,10 +7919,10 @@ sass-loader@^12.3.0:
     klona "^2.0.4"
     neo-async "^2.6.2"
 
-sass@^1.69.0:
-  version "1.69.0"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.69.0.tgz#5195075371c239ed556280cf2f5944d234f42679"
-  integrity sha512-l3bbFpfTOGgQZCLU/gvm1lbsQ5mC/WnLz3djL2v4WCJBDrWm58PO+jgngcGRNnKUh6wSsdm50YaovTqskZ0xDQ==
+sass@^1.69.4:
+  version "1.69.4"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.69.4.tgz#10c735f55e3ea0b7742c6efa940bce30e07fbca2"
+  integrity sha512-+qEreVhqAy8o++aQfCJwp0sklr2xyEzkm9Pp/Igu9wNPoe7EZEQ8X/MBvvXggI2ql607cxKg/RKOwDj6pp2XDA==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2209,10 +2209,10 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@^18.0.0", "@types/react-dom@^18.2.13":
-  version "18.2.13"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.13.tgz#89cd7f9ec8b28c8b6f0392b9591671fb4a9e96b7"
-  integrity sha512-eJIUv7rPP+EC45uNYp/ThhSpE16k22VJUknt5OLoH9tbXoi8bMhwLf5xRuWMywamNbWzhrSmU7IBJfPup1+3fw==
+"@types/react-dom@^18.0.0", "@types/react-dom@^18.2.14":
+  version "18.2.14"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.14.tgz#c01ba40e5bb57fc1dc41569bb3ccdb19eab1c539"
+  integrity sha512-V835xgdSVmyQmI1KLV2BEIUgqEuinxp9O4G6g3FqO/SqLac049E53aysv0oEFD2kHfejeKU+ZqL2bcFWj9gLAQ==
   dependencies:
     "@types/react" "*"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2209,10 +2209,10 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@^18.0.0", "@types/react-dom@^18.2.9":
-  version "18.2.9"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.9.tgz#c4ce3c7c91a134e1bff58692aa2d2f2f4029c38b"
-  integrity sha512-6nNhVzZ9joQ6F7lozrASuQKC0Kf6ArYMU+DqA2ZrUbB+d+9lC6ZLn1GxiEBI1edmAwvTULtuJ6uPZpv3XudwUg==
+"@types/react-dom@^18.0.0", "@types/react-dom@^18.2.13":
+  version "18.2.13"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.13.tgz#89cd7f9ec8b28c8b6f0392b9591671fb4a9e96b7"
+  integrity sha512-eJIUv7rPP+EC45uNYp/ThhSpE16k22VJUknt5OLoH9tbXoi8bMhwLf5xRuWMywamNbWzhrSmU7IBJfPup1+3fw==
   dependencies:
     "@types/react" "*"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2216,10 +2216,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-transition-group@^4.4.0", "@types/react-transition-group@^4.4.7":
-  version "4.4.7"
-  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.7.tgz#bf69f269d74aa78b99097673ca6dd6824a68ef1c"
-  integrity sha512-ICCyBl5mvyqYp8Qeq9B5G/fyBSRC0zx3XM3sCC6KkcMsNeAHqXBKkmat4GqdJET5jtYUpZXrxI5flve5qhi2Eg==
+"@types/react-transition-group@^4.4.0", "@types/react-transition-group@^4.4.8":
+  version "4.4.8"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.8.tgz#46f87d80512959cac793ecc610a93d80ef241ccf"
+  integrity sha512-QmQ22q+Pb+HQSn04NL3HtrqHwYMf4h3QKArOy5F8U5nEVMaihBs3SR10WiOM1iwPz5jIo8x/u11al+iEGZZrvg==
   dependencies:
     "@types/react" "*"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2223,10 +2223,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.2.30":
-  version "18.2.30"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.30.tgz#b84f786864fc46f18545364a54d5e1316308e59b"
-  integrity sha512-OfqdJnDsSo4UNw0bqAjFCuBpLYQM7wvZidz0hVxHRjrEkzRlvZL1pJVyOSY55HMiKvRNEo9DUBRuEl7FNlJ/Vg==
+"@types/react@*", "@types/react@^18.2.31":
+  version "18.2.31"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.31.tgz#74ae2630e4aa9af599584157abd3b95d96fb9b40"
+  integrity sha512-c2UnPv548q+5DFh03y8lEDeMfDwBn9G3dRwfkrxQMo/dOtRHUUO57k6pHvBIfH/VF4Nh+98mZ5aaSe+2echD5g==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2223,10 +2223,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.2.29":
-  version "18.2.29"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.29.tgz#88b48a287e00f6fdcd6f95662878fb701ae18b27"
-  integrity sha512-Z+ZrIRocWtdD70j45izShRwDuiB4JZqDegqMFW/I8aG5DxxLKOzVNoq62UIO82v9bdgi+DO1jvsb9sTEZUSm+Q==
+"@types/react@*", "@types/react@^18.2.30":
+  version "18.2.30"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.30.tgz#b84f786864fc46f18545364a54d5e1316308e59b"
+  integrity sha512-OfqdJnDsSo4UNw0bqAjFCuBpLYQM7wvZidz0hVxHRjrEkzRlvZL1pJVyOSY55HMiKvRNEo9DUBRuEl7FNlJ/Vg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2223,10 +2223,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.2.28":
-  version "18.2.28"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.28.tgz#86877465c0fcf751659a36c769ecedfcfacee332"
-  integrity sha512-ad4aa/RaaJS3hyGz0BGegdnSRXQBkd1CCYDCdNjBPg90UUpLgo+WlJqb9fMYUxtehmzF3PJaTWqRZjko6BRzBg==
+"@types/react@*", "@types/react@^18.2.29":
+  version "18.2.29"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.29.tgz#88b48a287e00f6fdcd6f95662878fb701ae18b27"
+  integrity sha512-Z+ZrIRocWtdD70j45izShRwDuiB4JZqDegqMFW/I8aG5DxxLKOzVNoq62UIO82v9bdgi+DO1jvsb9sTEZUSm+Q==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2223,10 +2223,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.2.25":
-  version "18.2.25"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.25.tgz#99fa44154132979e870ff409dc5b6e67f06f0199"
-  integrity sha512-24xqse6+VByVLIr+xWaQ9muX1B4bXJKXBbjszbld/UEDslGLY53+ZucF44HCmLbMPejTzGG9XgR+3m2/Wqu1kw==
+"@types/react@*", "@types/react@^18.2.28":
+  version "18.2.28"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.28.tgz#86877465c0fcf751659a36c769ecedfcfacee332"
+  integrity sha512-ad4aa/RaaJS3hyGz0BGegdnSRXQBkd1CCYDCdNjBPg90UUpLgo+WlJqb9fMYUxtehmzF3PJaTWqRZjko6BRzBg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,6 +31,14 @@
   dependencies:
     "@babel/highlight" "^7.18.6"
 
+"@babel/code-frame@^7.22.13":
+  version "7.22.13"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.13.tgz#e3c1c099402598483b7a8c46a721d1038803755e"
+  integrity sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==
+  dependencies:
+    "@babel/highlight" "^7.22.13"
+    chalk "^2.4.2"
+
 "@babel/compat-data@^7.17.7", "@babel/compat-data@^7.18.8":
   version "7.18.13"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.18.13.tgz#6aff7b350a1e8c3e40b029e46cbe78e24a913483"
@@ -73,6 +81,16 @@
   dependencies:
     "@babel/types" "^7.18.13"
     "@jridgewell/gen-mapping" "^0.3.2"
+    jsesc "^2.5.1"
+
+"@babel/generator@^7.23.0":
+  version "7.23.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.23.0.tgz#df5c386e2218be505b34837acbcb874d7a983420"
+  integrity sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==
+  dependencies:
+    "@babel/types" "^7.23.0"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    "@jridgewell/trace-mapping" "^0.3.17"
     jsesc "^2.5.1"
 
 "@babel/helper-annotate-as-pure@^7.18.6":
@@ -138,6 +156,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz#0c0cee9b35d2ca190478756865bb3528422f51be"
   integrity sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==
 
+"@babel/helper-environment-visitor@^7.22.20":
+  version "7.22.20"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz#96159db61d34a29dba454c959f5ae4a649ba9167"
+  integrity sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==
+
 "@babel/helper-explode-assignable-expression@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.18.6.tgz#41f8228ef0a6f1a036b8dfdfec7ce94f9a6bc096"
@@ -153,12 +176,27 @@
     "@babel/template" "^7.18.6"
     "@babel/types" "^7.18.9"
 
+"@babel/helper-function-name@^7.23.0":
+  version "7.23.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz#1f9a3cdbd5b2698a670c30d2735f9af95ed52759"
+  integrity sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==
+  dependencies:
+    "@babel/template" "^7.22.15"
+    "@babel/types" "^7.23.0"
+
 "@babel/helper-hoist-variables@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz#d4d2c8fb4baeaa5c68b99cc8245c56554f926678"
   integrity sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==
   dependencies:
     "@babel/types" "^7.18.6"
+
+"@babel/helper-hoist-variables@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz#c01a007dac05c085914e8fb652b339db50d823bb"
+  integrity sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==
+  dependencies:
+    "@babel/types" "^7.22.5"
 
 "@babel/helper-member-expression-to-functions@^7.18.9":
   version "7.18.9"
@@ -242,15 +280,32 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
+"@babel/helper-split-export-declaration@^7.22.6":
+  version "7.22.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz#322c61b7310c0997fe4c323955667f18fcefb91c"
+  integrity sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==
+  dependencies:
+    "@babel/types" "^7.22.5"
+
 "@babel/helper-string-parser@^7.18.10":
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.18.10.tgz#181f22d28ebe1b3857fa575f5c290b1aaf659b56"
   integrity sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==
 
+"@babel/helper-string-parser@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz#533f36457a25814cf1df6488523ad547d784a99f"
+  integrity sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==
+
 "@babel/helper-validator-identifier@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
   integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
+
+"@babel/helper-validator-identifier@^7.22.20":
+  version "7.22.20"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz#c4ae002c61d2879e724581d96665583dbc1dc0e0"
+  integrity sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==
 
 "@babel/helper-validator-option@^7.18.6":
   version "7.18.6"
@@ -285,10 +340,24 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/highlight@^7.22.13":
+  version "7.22.20"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.20.tgz#4ca92b71d80554b01427815e06f2df965b9c1f54"
+  integrity sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.22.20"
+    chalk "^2.4.2"
+    js-tokens "^4.0.0"
+
 "@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.18.10", "@babel/parser@^7.18.13":
   version "7.18.13"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.13.tgz#5b2dd21cae4a2c5145f1fbd8ca103f9313d3b7e4"
   integrity sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==
+
+"@babel/parser@^7.22.15", "@babel/parser@^7.23.0":
+  version "7.23.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.0.tgz#da950e622420bf96ca0d0f2909cdddac3acd8719"
+  integrity sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
@@ -1051,19 +1120,28 @@
     "@babel/parser" "^7.18.10"
     "@babel/types" "^7.18.10"
 
-"@babel/traverse@^7.18.11", "@babel/traverse@^7.18.13", "@babel/traverse@^7.18.9", "@babel/traverse@^7.7.2":
-  version "7.18.13"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.18.13.tgz#5ab59ef51a997b3f10c4587d648b9696b6cb1a68"
-  integrity sha512-N6kt9X1jRMLPxxxPYWi7tgvJRH/rtoU+dbKAPDM44RFHiMH8igdsaSBgFeskhSl/kLWLDUvIh1RXCrTmg0/zvA==
+"@babel/template@^7.22.15":
+  version "7.22.15"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.15.tgz#09576efc3830f0430f4548ef971dde1350ef2f38"
+  integrity sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==
   dependencies:
-    "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.18.13"
-    "@babel/helper-environment-visitor" "^7.18.9"
-    "@babel/helper-function-name" "^7.18.9"
-    "@babel/helper-hoist-variables" "^7.18.6"
-    "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/parser" "^7.18.13"
-    "@babel/types" "^7.18.13"
+    "@babel/code-frame" "^7.22.13"
+    "@babel/parser" "^7.22.15"
+    "@babel/types" "^7.22.15"
+
+"@babel/traverse@^7.18.11", "@babel/traverse@^7.18.13", "@babel/traverse@^7.18.9", "@babel/traverse@^7.7.2":
+  version "7.23.2"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.2.tgz#329c7a06735e144a506bdb2cad0268b7f46f4ad8"
+  integrity sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==
+  dependencies:
+    "@babel/code-frame" "^7.22.13"
+    "@babel/generator" "^7.23.0"
+    "@babel/helper-environment-visitor" "^7.22.20"
+    "@babel/helper-function-name" "^7.23.0"
+    "@babel/helper-hoist-variables" "^7.22.5"
+    "@babel/helper-split-export-declaration" "^7.22.6"
+    "@babel/parser" "^7.23.0"
+    "@babel/types" "^7.23.0"
     debug "^4.1.0"
     globals "^11.1.0"
 
@@ -1074,6 +1152,15 @@
   dependencies:
     "@babel/helper-string-parser" "^7.18.10"
     "@babel/helper-validator-identifier" "^7.18.6"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.22.15", "@babel/types@^7.22.5", "@babel/types@^7.23.0":
+  version "7.23.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.23.0.tgz#8c1f020c9df0e737e4e247c0619f58c68458aaeb"
+  integrity sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.22.5"
+    "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -1581,6 +1668,11 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
   integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
 
+"@jridgewell/resolve-uri@^3.1.0":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
+  integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
+
 "@jridgewell/set-array@^1.0.0", "@jridgewell/set-array@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
@@ -1599,6 +1691,11 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
+"@jridgewell/sourcemap-codec@^1.4.14":
+  version "1.4.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
+  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
 "@jridgewell/trace-mapping@^0.3.14", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.15"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz#aba35c48a38d3fd84b37e66c9c0423f9744f9774"
@@ -1606,6 +1703,14 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@jridgewell/trace-mapping@^0.3.17":
+  version "0.3.20"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz#72e45707cf240fa6b081d0366f8265b0cd10197f"
+  integrity sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
 
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.4"
@@ -3060,7 +3165,7 @@ case-sensitive-paths-webpack-plugin@^2.4.0:
   resolved "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.4.0.tgz#db64066c6422eed2e08cc14b986ca43796dbc6d4"
   integrity sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==
 
-chalk@^2.0.0, chalk@^2.4.1:
+chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==


### PR DESCRIPTION
- build(deps): bump @babel/traverse from 7.18.13 to 7.23.2 (#543)
- build(deps): bump @types/react from 18.2.25 to 18.2.28 (#539)
- build(deps): bump @types/react-dom from 18.2.9 to 18.2.13 (#540)
- build(deps): bump sass from 1.69.0 to 1.69.4 (#544)
- build(deps): bump @types/react from 18.2.28 to 18.2.29 (#545)
- build(deps): bump @types/react-transition-group from 4.4.7 to 4.4.8 (#546)
- build(deps): bump @types/react-dom from 18.2.13 to 18.2.14 (#547)
- chore: update dependabot.yml
- build(deps): bump @types/react from 18.2.29 to 18.2.30 (#554)
- build(deps): bump @types/react from 18.2.30 to 18.2.31 (#555)
- build(cd): setup auto deployment on release
- feat: add RankedVote embed to new page
- release(v3.7.0)
- feat(election): swap election embed to results embed
- release(v3.8.0)
