### PR TITLE
fix: change apiUrl to correct URL when in production

### DIFF
--- a/src/lib/sendAPIRequest.ts
+++ b/src/lib/sendAPIRequest.ts
@@ -1,5 +1,5 @@
 export async function sendAPIRequest<T>(path: string, method = "GET", body?: Record<string, unknown>) {
-  const apiUrl = import.meta.env.DEV ? "http://localhost:5000" : "https://api.uwaterloo.com";
+  const apiUrl = import.meta.env.DEV ? "http://localhost:5000" : "https://api.uwpokerclub.com";
 
   const res = await fetch(`${apiUrl}/${path}`, {
     credentials: "include",


### PR DESCRIPTION
Fixes typo in `sendAPIRequest` that fixes the URL that API requests are sent to in production mode

Closes #672
