### PR TITLE
deps(config): ignore dev dependencies in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 version: 2
 updates:
   - package-ecosystem: npm
+    allow:
+      - dependency-type: production
     directory: "/"
     schedule:
       interval: daily


### PR DESCRIPTION
Updates the dependabot config to only allow NPM updates for production dependencies.

Closes #697
