### PR TITLE
Redirect users to login page on 401 response

### DIFF
--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 export function useFetch<T>(path: string, method = "GET", body?: Record<string, unknown>) {
   const [status, setStatus] = useState(0);
   const [data, setData] = useState<T | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(true);
+  const navigate = useNavigate();
 
   const fetchData = useCallback(async () => {
     const apiUrl = import.meta.env.DEV ? "http://localhost:5000" : "https://api.uwpokerclub.com";
@@ -17,6 +19,11 @@ export function useFetch<T>(path: string, method = "GET", body?: Record<string, 
 
     setStatus(res.status);
 
+    if (res.status === 401) {
+      navigate("/admin/login");
+      return {};
+    }
+
     try {
       setData(await res.json());
     } catch (err) {
@@ -24,7 +31,7 @@ export function useFetch<T>(path: string, method = "GET", body?: Record<string, 
     }
 
     setIsLoading(false);
-  }, [path, body, method]);
+  }, [path, body, method, navigate]);
 
   useEffect(() => {
     fetchData();

--- a/src/lib/sendAPIRequest.ts
+++ b/src/lib/sendAPIRequest.ts
@@ -1,3 +1,5 @@
+import { redirect } from "react-router-dom";
+
 export async function sendAPIRequest<T>(path: string, method = "GET", body?: Record<string, unknown>) {
   const apiUrl = import.meta.env.DEV ? "http://localhost:5000" : "https://api.uwpokerclub.com";
 
@@ -9,6 +11,11 @@ export async function sendAPIRequest<T>(path: string, method = "GET", body?: Rec
   });
 
   const status = res.status;
+
+  if (status === 401) {
+    redirect("/admin/login");
+    return { status, data: undefined };
+  }
 
   let data: T | null = null;
 


### PR DESCRIPTION
Adds a check in the sendAPIRequest and useFetch functions for a 401
response from the API. They will now redirect the user back to the login
page when the API responds with a 401.

Closes #477
