### PR TITLE
Add new SDK library to fix event registration page error

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_API_URL="http://localhost:5000"

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VITE_API_URL="https://api.uwpokerclub.com"

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from "./useFetch";
 export * from "./useLocalStorage";
+export * from "./useEvent";

--- a/src/hooks/useEvent.ts
+++ b/src/hooks/useEvent.ts
@@ -1,0 +1,24 @@
+import { useState, useEffect } from "react";
+
+import { Event, getEvent } from "../sdk/events";
+
+export function useEvent(eventId: number) {
+  const [loading, setLoading] = useState(true);
+  const [event, setEvent] = useState<Event | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getEvent(eventId)
+      .then((event) => {
+        setEvent(event);
+      })
+      .catch((err) => {
+        setError(err.message);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [eventId]);
+
+  return { event, error, loading };
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,1 +1,2 @@
 export * from "./sendAPIRequest";
+export * from "./sendRequest";

--- a/src/lib/sendRequest.ts
+++ b/src/lib/sendRequest.ts
@@ -1,0 +1,28 @@
+import { redirect } from "react-router-dom";
+
+type ErrorResponse = {
+  code: number;
+  type: string;
+  message: string;
+};
+
+export async function sendRequest<T>(path: string, method = "GET"): Promise<T> {
+  const res = await fetch(`${import.meta.env.VITE_API_URL}/${path}`, {
+    credentials: "include",
+    method,
+  });
+
+  if (res.ok) {
+    const data: T = await res.json();
+    return data;
+  }
+
+  const errorData: ErrorResponse = await res.json();
+
+  if (res.status === 401) {
+    redirect("/admin/login");
+    throw new Error(errorData.message);
+  }
+
+  throw new Error(errorData.message);
+}

--- a/src/sdk/events/getEvent.ts
+++ b/src/sdk/events/getEvent.ts
@@ -1,0 +1,32 @@
+import { sendRequest } from "../../lib";
+import { GetSemesterResponse } from "../semesters/responses";
+import { GetStructureResponse } from "../structures/responses";
+import { ListParticipantsResponse } from "../participants/responses";
+import { GetEventResponse } from "./responses";
+import type { Event } from "./model";
+
+export async function getEvent(eventId: number): Promise<Event> {
+  const eventData = await sendRequest<GetEventResponse>(`events/${eventId}`);
+  const semesterData = await sendRequest<GetSemesterResponse>(`semesters/${eventData.semesterId}`);
+  const structureData = await sendRequest<GetStructureResponse>(`structures/${eventData.structureId}`);
+  const participantsData = await sendRequest<ListParticipantsResponse>(`participants?eventId=${eventId}`);
+
+  const event: Event = {
+    ...eventData,
+    startDate: new Date(eventData.startDate),
+    semester: {
+      ...semesterData,
+      startDate: new Date(semesterData.startDate),
+      endDate: new Date(semesterData.endDate),
+    },
+    structure: {
+      ...structureData,
+    },
+    participants: participantsData.map((p) => ({
+      ...p,
+      signedOutAt: new Date(p.signedOutAt),
+    })),
+  };
+
+  return event;
+}

--- a/src/sdk/events/index.ts
+++ b/src/sdk/events/index.ts
@@ -1,0 +1,2 @@
+export * from "./model";
+export * from "./getEvent";

--- a/src/sdk/events/model.ts
+++ b/src/sdk/events/model.ts
@@ -1,0 +1,17 @@
+import type { Semester } from "../semesters";
+import type { Structure } from "../structures";
+import type { Participant } from "../participants";
+
+export interface Event {
+  id: number;
+  name: string;
+  format: string;
+  notes: string;
+  startDate: Date;
+  rebuys: number;
+  pointsMultiplier: number;
+  state: number;
+  semester: Semester;
+  structure: Structure;
+  participants: Participant[];
+}

--- a/src/sdk/events/responses.ts
+++ b/src/sdk/events/responses.ts
@@ -1,0 +1,12 @@
+export type GetEventResponse = {
+  id: number;
+  name: string;
+  format: string;
+  notes: string;
+  semesterId: string;
+  startDate: string;
+  structureId: number;
+  rebuys: number;
+  state: number;
+  pointsMultiplier: number;
+};

--- a/src/sdk/memberships/getEligibleMembers.ts
+++ b/src/sdk/memberships/getEligibleMembers.ts
@@ -1,0 +1,22 @@
+import { getEvent } from "../events";
+import { getMembers } from "./getMembers";
+
+import type { Membership } from "./model";
+
+/**
+ * getEligibleMembers returns a list of members who are eligible to join an event. The meaning "eligible" is
+ *  any member that is not already registered for the event.
+ *
+ *  @param eventId The ID number of the event to get eligible members for.
+ */
+export async function getEligibleMembers(eventId: number): Promise<Membership[]> {
+  const event = await getEvent(eventId);
+  const members = await getMembers(event.semester.id);
+
+  // Filter members list to remove any members who are already registered for the event
+  const registeredIds = new Set(event.participants.map((p) => p.membershipId));
+  const eligibleMembers = members.filter((m) => !registeredIds.has(m.id));
+
+  // Return the filtered list
+  return eligibleMembers;
+}

--- a/src/sdk/memberships/getMembers.ts
+++ b/src/sdk/memberships/getMembers.ts
@@ -1,0 +1,13 @@
+import { sendRequest } from "../../lib";
+import type { ListMembershipsResponse } from "./responses";
+import type { Membership } from "./model";
+
+/**
+ * getMembers fetches all memberships for a given semester.
+ *
+ * @param semesterId The UUID of the semester.
+ */
+export async function getMembers(semesterId: string): Promise<Membership[]> {
+  const membershipData = sendRequest<ListMembershipsResponse>(`memberships?semesterId=${semesterId}`);
+  return membershipData;
+}

--- a/src/sdk/memberships/index.ts
+++ b/src/sdk/memberships/index.ts
@@ -1,0 +1,3 @@
+export * from "./model";
+export * from "./getMembers";
+export * from "./getEligibleMembers";

--- a/src/sdk/memberships/model.ts
+++ b/src/sdk/memberships/model.ts
@@ -1,0 +1,9 @@
+export interface Membership {
+  id: string;
+  userId: number;
+  firstName: string;
+  lastName: string;
+  paid: boolean;
+  discounted: boolean;
+  attendance: number;
+}

--- a/src/sdk/memberships/responses.ts
+++ b/src/sdk/memberships/responses.ts
@@ -1,0 +1,9 @@
+export type ListMembershipsResponse = {
+  id: string;
+  userId: number;
+  firstName: string;
+  lastName: string;
+  paid: boolean;
+  discounted: boolean;
+  attendance: number;
+}[];

--- a/src/sdk/participants/index.ts
+++ b/src/sdk/participants/index.ts
@@ -1,0 +1,1 @@
+export * from "./model";

--- a/src/sdk/participants/model.ts
+++ b/src/sdk/participants/model.ts
@@ -1,0 +1,8 @@
+export interface Participant {
+  id: number;
+  membershipId: string;
+  placement: number;
+  signedOutAt: Date;
+  firstName: string;
+  lastName: string;
+}

--- a/src/sdk/participants/responses.ts
+++ b/src/sdk/participants/responses.ts
@@ -1,0 +1,8 @@
+export type ListParticipantsResponse = {
+  id: number;
+  membershipId: string;
+  firstName: string;
+  lastName: string;
+  signedOutAt: string;
+  placement: number;
+}[];

--- a/src/sdk/semesters/index.ts
+++ b/src/sdk/semesters/index.ts
@@ -1,0 +1,1 @@
+export * from "./model.ts";

--- a/src/sdk/semesters/model.ts
+++ b/src/sdk/semesters/model.ts
@@ -1,0 +1,12 @@
+export interface Semester {
+  id: string;
+  name: string;
+  meta: string;
+  startDate: Date;
+  endDate: Date;
+  startingBudget: number;
+  currentBudget: number;
+  membershipFee: number;
+  membershipDiscountFee: number;
+  rebuyFee: number;
+}

--- a/src/sdk/semesters/responses.ts
+++ b/src/sdk/semesters/responses.ts
@@ -1,0 +1,12 @@
+export type GetSemesterResponse = {
+  id: string;
+  name: string;
+  meta: string;
+  startDate: string;
+  endDate: string;
+  startingBudget: number;
+  currentBudget: number;
+  membershipFee: number;
+  membershipDiscountFee: number;
+  rebuyFee: number;
+};

--- a/src/sdk/structures/index.ts
+++ b/src/sdk/structures/index.ts
@@ -1,0 +1,1 @@
+export * from "./model.ts";

--- a/src/sdk/structures/model.ts
+++ b/src/sdk/structures/model.ts
@@ -1,0 +1,12 @@
+export interface Blind {
+  small: number;
+  big: number;
+  ante: number;
+  time: number;
+}
+
+export interface Structure {
+  id: number;
+  name: string;
+  blinds: Blind[];
+}

--- a/src/sdk/structures/responses.ts
+++ b/src/sdk/structures/responses.ts
@@ -1,0 +1,10 @@
+export type GetStructureResponse = {
+  id: number;
+  name: string;
+  blinds: {
+    small: number;
+    big: number;
+    ante: number;
+    time: number;
+  }[];
+};

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
Fixes an issue where the event registration page would error because the event details weren't available yet when the call to memberships was made (needs the event semester ID). To fix this issue, I just implemented a SDK layer that handles requests for this page in one call, and future updates to pages can make use of this SDK or add to it.

Closes #747