### PR TITLE
Make semester budget stats responsive

### DIFF
--- a/src/features/semesters/components/SemesterInfo.module.css
+++ b/src/features/semesters/components/SemesterInfo.module.css
@@ -1,8 +1,11 @@
 .highlights {
   margin: 0.5rem 0;
   display: flex;
+  overflow: auto;
 }
 
 .item {
   margin: 0 0.5rem;
+  text-wrap: nowrap;
+  min-width: fit-content;
 }

--- a/src/features/semesters/components/SemesterInfo.tsx
+++ b/src/features/semesters/components/SemesterInfo.tsx
@@ -12,7 +12,7 @@ export function SemesterInfo() {
   const { data: semester } = useFetch<Semester>(`semesters/${semesterId}`);
 
   return (
-    <div>
+    <>
       <div className={styles.highlights}>
         <div className={`card ${styles.item}`}>
           <div className="card-body">
@@ -44,21 +44,19 @@ export function SemesterInfo() {
               {Number(semester?.membershipFee).toLocaleString("en-US", {
                 style: "currency",
                 currency: "USD",
-              })}
+              })}{" "}
+              <i>
+                (
+                {Number(semester?.membershipDiscountFee).toLocaleString("en-US", {
+                  style: "currency",
+                  currency: "USD",
+                })}
+                )
+              </i>
             </h2>
-            <h6 className="card-subtitle mb-2 text-muted">Membership Fee</h6>
-          </div>
-        </div>
-
-        <div className={`card ${styles.item}`}>
-          <div className="card-body">
-            <h2 className="card-title">
-              {Number(semester?.membershipDiscountFee).toLocaleString("en-US", {
-                style: "currency",
-                currency: "USD",
-              })}
-            </h2>
-            <h6 className="card-subtitle mb-2 text-muted">Membership Fee (Discounted)</h6>
+            <h6 className="card-subtitle mb-2 text-muted">
+              Membership Fee <i>(Discount)</i>
+            </h6>
           </div>
         </div>
 
@@ -78,6 +76,6 @@ export function SemesterInfo() {
       <MembershipsTable semesterId={semesterId} />
 
       <TransactionsTable semesterId={semesterId} />
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
Updates the CSS of the semester stat cards at the top of the semester
info page so they are responsive. This includes making the entire bar
scroll-able. Additionally I removed the card for the discounted
membership fee and just included it in the membership fee card.

Closes #754
