### PR TITLE
fix: change authentication check to make request to check session

### DIFF
--- a/src/contexts/auth/RequireAuth.tsx
+++ b/src/contexts/auth/RequireAuth.tsx
@@ -9,6 +9,10 @@ export function RequireAuth({ children }: RequireAuthProps) {
   const auth = useAuth();
   const location = useLocation();
 
+  if (auth.authenticated === null) {
+    return <></>;
+  }
+
   if (!auth.authenticated) {
     return <Navigate to="/admin/login" state={{ from: location }} replace />;
   }

--- a/src/contexts/auth/context.ts
+++ b/src/contexts/auth/context.ts
@@ -1,13 +1,13 @@
 import { createContext, useContext } from "react";
 
 type AuthContext = {
-  authenticated: boolean;
+  authenticated: boolean | null;
   signIn: (cb: () => void) => void;
   signOut: (cb: () => void) => void;
 };
 
 export const authContext = createContext<AuthContext>({
-  authenticated: false,
+  authenticated: null,
   signIn: () => null,
   signOut: () => null,
 });

--- a/src/lib/sendRequest.ts
+++ b/src/lib/sendRequest.ts
@@ -6,7 +6,7 @@ type ErrorResponse = {
   message: string;
 };
 
-export async function sendRequest<T>(path: string, method = "GET"): Promise<T> {
+export async function sendRequest<T>(path: string, method = "GET", redirectOn401 = true): Promise<T> {
   const res = await fetch(`${import.meta.env.VITE_API_URL}/${path}`, {
     credentials: "include",
     method,
@@ -19,7 +19,7 @@ export async function sendRequest<T>(path: string, method = "GET"): Promise<T> {
 
   const errorData: ErrorResponse = await res.json();
 
-  if (res.status === 401) {
+  if (res.status === 401 && redirectOn401) {
     redirect("/admin/login");
   }
 

--- a/src/sdk/session/getSession.ts
+++ b/src/sdk/session/getSession.ts
@@ -1,0 +1,7 @@
+import { sendRequest } from "../../lib";
+import { GetSessionResponse } from "./responses";
+
+export async function getSession() {
+  const session = await sendRequest<GetSessionResponse>("session", "GET", false);
+  return session;
+}

--- a/src/sdk/session/index.ts
+++ b/src/sdk/session/index.ts
@@ -1,0 +1,2 @@
+export * from "./responses";
+export * from "./getSession";

--- a/src/sdk/session/responses.ts
+++ b/src/sdk/session/responses.ts
@@ -1,0 +1,3 @@
+export type GetSessionResponse = {
+  username: string;
+};


### PR DESCRIPTION
Fixes a bug where the users session would get reset on the app if the
page got refreshed. This was due to the old authentication checking for
the existence of the cookie. However, the cookie was recently made HTTP
only breaking this check. Now, the authentication check makes a request
to the get session endpoint.

Closes #749
