### PR TITLE
fix(clock): disable start on render when clock is paused

### DIFF
--- a/src/features/tournament-clock/components/ClockDisplay.tsx
+++ b/src/features/tournament-clock/components/ClockDisplay.tsx
@@ -7,6 +7,7 @@ import styles from "./ClockDisplay.module.css";
 type Props = {
   levelTime: number;
   startOnRender: boolean;
+  onTimerPause: () => void;
   onTimerEnd: () => void;
   onPreviousLevel: () => void;
   onNextLevel: () => void;
@@ -18,7 +19,14 @@ const MS_IN_MINUTE = MS_IN_SECOND * SECONDS_IN_MINUTE;
 const LOW_PITCH_BEEP = 493.883;
 const HIGH_PITCH_BEEP = 659.255;
 
-export function ClockDisplay({ levelTime, startOnRender, onTimerEnd, onPreviousLevel, onNextLevel }: Props) {
+export function ClockDisplay({
+  levelTime,
+  startOnRender,
+  onTimerPause,
+  onTimerEnd,
+  onPreviousLevel,
+  onNextLevel,
+}: Props) {
   // The time when the timer is supposed to end (in ms)
   const [endTime, setEndTime] = useState(Date.now() + levelTime * MS_IN_MINUTE);
   // The current time (in ms)
@@ -51,6 +59,7 @@ export function ClockDisplay({ levelTime, startOnRender, onTimerEnd, onPreviousL
 
     // Clear the previous interval to prevent multiple intervals from being started
     clearInterval(intervalRef.current!);
+    intervalRef.current = null;
 
     // Every half second, update the current time, which will update the time on the clock
     intervalRef.current = setInterval(() => {
@@ -63,7 +72,10 @@ export function ClockDisplay({ levelTime, startOnRender, onTimerEnd, onPreviousL
     setIsPaused(true);
 
     clearInterval(intervalRef.current!);
-  }, []);
+    intervalRef.current = null;
+
+    onTimerPause();
+  }, [onTimerPause]);
 
   // Handles adding 1 minute to the clock when the add button is clicked
   const handleAddTime = useCallback(() => {
@@ -88,10 +100,10 @@ export function ClockDisplay({ levelTime, startOnRender, onTimerEnd, onPreviousL
 
   // Handles starting the clock on render
   useEffect(() => {
-    if (startOnRender) {
+    if (startOnRender && intervalRef.current === null) {
       handleStart();
     }
-  }, [handleStart, isPaused, startOnRender]);
+  }, [handleStart, startOnRender]);
 
   return (
     <section className={styles.container}>

--- a/src/features/tournament-clock/components/TournamentClock.tsx
+++ b/src/features/tournament-clock/components/TournamentClock.tsx
@@ -47,6 +47,9 @@ export function TournamentClock({ levels }: Props) {
     };
   }, []);
 
+  // Handles stopping the auto-start feature when the timer is paused
+  const handleTimerPause = useCallback(() => setShouldStart(false), []);
+
   // Handles advancing to the next level when the timer is finished
   const handleTimerEnd = useCallback(() => {
     if (levelIndex >= levels.length - 1) {
@@ -96,6 +99,7 @@ export function TournamentClock({ levels }: Props) {
         key={levelIndex}
         startOnRender={shouldStart}
         levelTime={levels[levelIndex].time}
+        onTimerPause={handleTimerPause}
         onTimerEnd={handleTimerEnd}
         onPreviousLevel={handlePreviousLevel}
         onNextLevel={handleNextLevel}


### PR DESCRIPTION
Fixes an issue where the clock could not be paused once a level had advanced. The issue was that the `startOnRender` prop and `shouldStart` state was being set to `true` when the level advanced, however it was never being set back to `false`, so if you paused the clock, a new render would happen, and the effect watching `startOnRender` would run and see that it is `true` and would restart the clock.

Fixes #785
