### PR TITLE
fix(events): fix edit icon to only display on hover

### DIFF
--- a/src/features/events/components/ListEvent.module.css
+++ b/src/features/events/components/ListEvent.module.css
@@ -2,8 +2,14 @@
   display: none;
 }
 
+.card {
+  display: flex;
+  justify-content: space-between;
+}
+
 .card:hover .actions {
   display: flex;
+  align-items: center;
 }
 
 

--- a/src/features/events/components/ListEvents.tsx
+++ b/src/features/events/components/ListEvents.tsx
@@ -4,6 +4,7 @@ import { useFetch } from "../../../hooks";
 import { Semester, Event } from "../../../types";
 
 import styles from "./ListEvent.module.css";
+import { EventState } from "../../../sdk/events";
 
 export function ListEvents() {
   const { data: events, isLoading } = useFetch<Event[]>("events");
@@ -44,13 +45,8 @@ export function ListEvents() {
 
           <div className="list-group">
             {filteredEvents.map((event) => (
-              <Link
-                key={event.id}
-                to={`${event.id}`}
-                className={`${styles.card} list-group-item d-flex justify-content-between`}
-                data-qa={`event-${event.id}-card`}
-              >
-                <div>
+              <div key={event.id} data-qa={`event-${event.id}-card`} className={`${styles.card} list-group-item`}>
+                <Link key={event.id} to={`${event.id}`} className="text-decoration-none text-reset flex-grow-1">
                   <h4 data-qa={`${event.id}-name`} className="list-group-item-heading bold">
                     {event.name}
                   </h4>
@@ -75,26 +71,28 @@ export function ListEvents() {
                     </p>
                     <p> {event.count || "No"} Entries </p>
                   </div>
-                </div>
-                <div data-qa="actions" className={`${styles.actions} d-flex align-items-center me-4`}>
-                  <Link data-qa="edit-event-btn" to={`${event.id}/edit`}>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="24"
-                      height="24"
-                      fill="currentColor"
-                      className="bi bi-pencil-square"
-                      viewBox="0 0 16 16"
-                    >
-                      <path d="M15.502 1.94a.5.5 0 0 1 0 .706L14.459 3.69l-2-2L13.502.646a.5.5 0 0 1 .707 0l1.293 1.293zm-1.75 2.456-2-2L4.939 9.21a.5.5 0 0 0-.121.196l-.805 2.414a.25.25 0 0 0 .316.316l2.414-.805a.5.5 0 0 0 .196-.12l6.813-6.814z" />
-                      <path
-                        fillRule="evenodd"
-                        d="M1 13.5A1.5 1.5 0 0 0 2.5 15h11a1.5 1.5 0 0 0 1.5-1.5v-6a.5.5 0 0 0-1 0v6a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5H9a.5.5 0 0 0 0-1H2.5A1.5 1.5 0 0 0 1 2.5z"
-                      />
-                    </svg>
-                  </Link>
-                </div>
-              </Link>
+                </Link>
+                {event.state !== EventState.Ended && (
+                  <div data-qa="actions" className={`${styles.actions} me-4`}>
+                    <Link data-qa="edit-event-btn" to={`${event.id}/edit`}>
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="24"
+                        height="24"
+                        fill="currentColor"
+                        className="bi bi-pencil-square"
+                        viewBox="0 0 16 16"
+                      >
+                        <path d="M15.502 1.94a.5.5 0 0 1 0 .706L14.459 3.69l-2-2L13.502.646a.5.5 0 0 1 .707 0l1.293 1.293zm-1.75 2.456-2-2L4.939 9.21a.5.5 0 0 0-.121.196l-.805 2.414a.25.25 0 0 0 .316.316l2.414-.805a.5.5 0 0 0 .196-.12l6.813-6.814z" />
+                        <path
+                          fillRule="evenodd"
+                          d="M1 13.5A1.5 1.5 0 0 0 2.5 15h11a1.5 1.5 0 0 0 1.5-1.5v-6a.5.5 0 0 0-1 0v6a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5H9a.5.5 0 0 0 0-1H2.5A1.5 1.5 0 0 0 1 2.5z"
+                        />
+                      </svg>
+                    </Link>
+                  </div>
+                )}
+              </div>
             ))}
           </div>
         </div>

--- a/src/sdk/events/model.ts
+++ b/src/sdk/events/model.ts
@@ -2,6 +2,11 @@ import type { Semester } from "../semesters";
 import type { Structure } from "../structures";
 import type { Participant } from "../participants";
 
+export enum EventState {
+  Started = 0,
+  Ended,
+}
+
 export interface Event {
   id: number;
   name: string;
@@ -10,7 +15,7 @@ export interface Event {
   startDate: Date;
   rebuys: number;
   pointsMultiplier: number;
-  state: number;
+  state: EventState;
   semester: Semester;
   structure: Structure;
   participants: Participant[];


### PR DESCRIPTION
Fixes an issue where the event edit icon was always being displayed. The
icon now only displays when the event has not ended and the user hovers
over the event card.

Fixes #787
